### PR TITLE
Promise.all and empty arrays

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -88,6 +88,8 @@
     };
 
     Promise.all = function (promises) {
+        if(!(promises instanceof Array) || promises.length === 0)
+            return Promise.resolve([]);
         return new Promise(function (resolve, reject) {
             var values = [];
             promises = promises.map(toPromise);


### PR DESCRIPTION
I think the behavior of Promise.all is incorrect.
I tried the native implementations of Google Chrome and Firefox and both do the same thing when Promise.all is called with either an empty array or another type of value as argument : directly resolve the promise.
There is one difference between the browsers, if one calls for example Promise.all("myValue") :
- Chrome resolves with [ ].
- Firefox resolves with ["myValue"].
