### PR TITLE
bower.json specifications update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "Promise polyfill",
+    "name": "promise-polyfill",
     "version": "1.0.10",
     "description": "ES6 Promise polyfill",
     "keywords": [


### PR DESCRIPTION
Making name lowercase and replace space with dash to conform to bower spec: https://github.com/bower/spec/blob/master/json.md#name

Originally saw this error running `bower install` with this library in project dependencies:

```
bower promises#*                cached https://github.com/Octane/Promise.git#1.0.10
bower promises#*              validate 1.0.10 against https://github.com/Octane/Promise.git#*
bower                        ENOTFOUND Package Promise polyfill=promises not found
```
